### PR TITLE
Make package only use PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 gulp-jasmine-phantom
 =============
 
-A gulp plugin that runs Jasmine tests with either PhantomJS or minijasminenode2.
+A gulp plugin that runs Jasmine tests with PhantomJS.
+
+This fork is intended for use in environments where PhantomJS is present and the Node version is `0.10.x`*.
+
+It removes the ability to use mininodejasmine2 due to its inclusion introducing the need for 
+`execSync` which is not available when using a version of Node under `0.12.x`.
+
+*The current need is for running JS unit tests on [Travis-CI](https://travis-ci.org/) where the primary language is not Node. In this situation Node is available but is (as of 08 Sept 2015) locked to `0.10.36`.
 
 Dependencies
 ------------
-
-This module uses `execSync` which is not available in any version of Node under `0.12.x`.
-If you have any specific concerns about upgrading versions of Node or reasons not use
-`execSync` feel free to open an issue!
 
 Before you install `gulp-jasmine-phantom` please ensure that you have PhantomJS
 installed on your machine. The plugin assumes that the `phantomjs` binary is
@@ -25,26 +28,12 @@ Install
 -----
 
 ```
-$ npm install --save-dev gulp-jasmine-phantom
+$ npm install --save-dev git://github.com/alphagov/gulp-jasmine-phantom.git#<latest commit SHA>
 ```
 
 Usage
 -----
-By default, `gulp-jasmine-phantom` runs your tests with `minijasminenode` and
-not `phantomjs`.
-This is an effort to keep your tasks running as quickly as possible!
-
 Basic usage:
-```javascript
-var gulp = require('gulp');
-var jasmine = require('gulp-jasmine-phantom');
-
-gulp.task('default', function () {
-  return gulp.src('spec/test.js')
-          .pipe(jasmine());
-});
-```
-To use `phantomjs` for tests (ie: integration tests) use the following setup:
 
 ```javascript
 var gulp = require('gulp');
@@ -52,29 +41,7 @@ var jasmine = require('gulp-jasmine-phantom');
 
 gulp.task('default', function() {
   return gulp.src('spec/test.js')
-          .pipe(jasmine({
-            integration: true
-          }));
-});
-```
-
-Also, remember you can always run any multitude of tests using different Gulp
-tasks. For example, running unit tests and integration tests asynchronously.
-
-```javascript
-var gulp = require('gulp');
-var jasmine = require('gulp-jasmine-phantom');
-
-gulp.task('unitTests', function () {
-  return gulp.src('spec/test.js')
           .pipe(jasmine());
-});
-
-gulp.task('integrationTests', function() {
-  return gulp.src('spec/test.js')
-          .pipe(jasmine({
-            integration: true
-          }));
 });
 ```
 
@@ -86,12 +53,6 @@ Type: `string` <br />
 Default: '2.0'
 
 Specifies the version of Jasmine you want to run. Possible options are in the `vendor/` folder. Just specify what `2.x` minor release you want.
-
-#### integration
-Type: `boolean` <br />
-Default: false
-
-Run your tests with `phantomjs`
 
 #### keepRunner
 Type: `boolean | string` <br />

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var path = require('path'),
     handlebar = require('handlebars'),
     fs = require('fs'),
     execFile = require('child_process').execFile,
-    requireUncached = require('require-uncached');
+    requireUncached = require('require-uncached'),
+    semver = require('semver');
 
 /*
  * Global variables
@@ -153,6 +154,12 @@ module.exports = function (options) {
   gulpOptions = options || {};
 
   configJasmine(gulpOptions.jasmineVersion);
+
+  // if Node is above 0.12.0, notify
+  if (semver.satisfies(process.version.match(/^v(\d+\.\d+\.\d+)/)[1], '>=0.12.0')) {
+    console.log('#################### Your version of Node is above 0.12.0             ####################');
+    console.log('#################### Please use dflynn15/gulp-jasmine-phantom instead ####################');
+  }
 
   return through.obj(
     function (file, encoding, callback) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var path = require('path'),
     handlebar = require('handlebars'),
     fs = require('fs'),
     execFile = require('child_process').execFile,
-    exec = require('child_process').execSync,
     requireUncached = require('require-uncached');
 
 /*
@@ -42,23 +41,6 @@ function configJasmine(version) {
   **/
 function cleanup(path) {
   fs.unlink(path);
-}
-
-function hasGlobalPhantom() {
-  if(process.platform === 'win32') {
-    try {
-      exec('where phantomjs');
-    } catch (e) {
-      return false;
-    }
-  } else {
-    try {
-      exec('which phantomjs');
-    } catch (e) {
-      return false;
-    }
-  }
-  return true;
 }
 
 /**
@@ -98,12 +80,7 @@ function execPhantom(phantom, childArguments, onComplete) {
   * [jasmine-runner.js, specRunner.html]
   **/
 function runPhantom(childArguments, onComplete) {
-  if(hasGlobalPhantom()) {
-    execPhantom(phantomExecutable, childArguments, onComplete);
-  } else {
-    gutil.log(gutil.colors.yellow('gulp-jasmine-phantom: Global Phantom undefined, trying to execute from node_modules/phantomjs'));
-    execPhantom(process.cwd() + '/node_modules/.bin/' + phantomExecutable, childArguments, onComplete);
-  }
+  execPhantom(phantomExecutable, childArguments, onComplete);
 }
 
 /*
@@ -158,16 +135,12 @@ function compileRunner(options) {
         throw error;
       }
 
-      if(gulpOptions.integration) {
-        var childArgs = [
-          path.join(__dirname, '/lib/jasmine-runner.js'),
-          specHtml,
-          JSON.stringify(gulpOptions)
-        ];
-        runPhantom(childArgs, onComplete);
-      } else {
-        onComplete(null);
-      }
+      var childArgs = [
+        path.join(__dirname, '/lib/jasmine-runner.js'),
+        specHtml,
+        JSON.stringify(gulpOptions)
+      ];
+      runPhantom(childArgs, onComplete);
     });
   });
 }
@@ -181,104 +154,41 @@ module.exports = function (options) {
 
   configJasmine(gulpOptions.jasmineVersion);
 
-  if(!!gulpOptions.integration) {
-    return through.obj(
-      function (file, encoding, callback) {
-        if (file.isNull()) {
-          callback(null, file);
-          return;
-        }
-        if (file.isStream()) {
-          callback(new gutil.PluginError('gulp-jasmine-phantom', 'Streaming not supported'));
-          return;
-        }
-        filePaths.push(file.path);
-        callback(null, file);
-      }, function (callback) {
-        gutil.log('Running Jasmine with PhantomJS');
-        try {
-          if(gulpOptions.specHtml) {
-            runPhantom(
-              [
-                path.join(__dirname, '/lib/jasmine-runner.js'),
-                path.resolve(gulpOptions.specHtml),
-                JSON.stringify(gulpOptions)
-              ], function(success) {
-              callback(success);
-            });
-          } else {
-            compileRunner({
-              files: filePaths,
-              onComplete: function(success) {
-                callback(success);
-              }
-            });
-          }
-        } catch(error) {
-          callback(new gutil.PluginError('gulp-jasmine-phantom', error));
-        }
-      }
-    );
-  }
-
   return through.obj(
-    function(file, encoding, callback) {
+    function (file, encoding, callback) {
       if (file.isNull()) {
         callback(null, file);
         return;
       }
-
       if (file.isStream()) {
         callback(new gutil.PluginError('gulp-jasmine-phantom', 'Streaming not supported'));
         return;
       }
-
-      /**
-      * Get the cache object of the specs.js file,
-      * get its children and delete the childrens cache
-      */
-      var modId = require.resolve(path.resolve(file.path));
-      var files = require.cache[modId];
-      if (typeof files !== 'undefined') {
-        for (var i in files.children) {
-          delete require.cache[files.children[i].id];
-        }
-      }
-      delete require.cache[modId];
-
-      miniJasmineLib.addSpecs(file.path);
       filePaths.push(file.path);
       callback(null, file);
-    }, 
-    function(callback) {
-      gutil.log('Running Jasmine with minijasminenode2');
+    }, function (callback) {
+      gutil.log('Running Jasmine with PhantomJS');
       try {
-        miniJasmineLib.executeSpecs({
-          reporter: terminalReporter,
-          showColors: true,
-          includeStackTrace: gulpOptions.includeStackTrace,
-          onComplete: function() {
-            if(gulpOptions.keepRunner) {
-              try {
-                compileRunner({
-                  files: filePaths,
-                  onComplete: function() {
-                    callback(null);
-                  }
-                });
-              } catch(error) {
-                callback(new gutil.PluginError('gulp-jasmine-phantom', error));
-              }
-            } else {
-              callback(null);
+        if(gulpOptions.specHtml) {
+          runPhantom(
+            [
+              path.join(__dirname, '/lib/jasmine-runner.js'),
+              path.resolve(gulpOptions.specHtml),
+              JSON.stringify(gulpOptions)
+            ], function(success) {
+            callback(success);
+          });
+        } else {
+          compileRunner({
+            files: filePaths,
+            onComplete: function(success) {
+              callback(success);
             }
-          }
-        });
-
+          });
+        }
       } catch(error) {
         callback(new gutil.PluginError('gulp-jasmine-phantom', error));
       }
-
     }
   );
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "through2": "^0.6.1",
     "handlebars": "^2.0.0",
     "require-uncached": "^1.0.2",
-    "glob": "^4.0.6"
+    "glob": "^4.0.6",
+    "semver": "5.0.1"
   },
   "devDependencies": {
     "JSON": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "gulp-jasmine-phantom",
   "version": "2.0.1",
-  "description": "Jasmine 2.0 suite runner, optionally with PhantomJS",
+  "description": "Jasmine 2.0 suite runner using PhantomJS",
   "license": "MIT",
   "repository": "dflynn15/gulp-jasmine-phantom",
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=0.10.0"
   },
   "keywords": [
     "gulpplugin",
@@ -23,7 +23,6 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "minijasminenode2": "dflynn15/minijasminenode",
     "through2": "^0.6.1",
     "handlebars": "^2.0.0",
     "require-uncached": "^1.0.2",


### PR DESCRIPTION
These changes are intended to make a version of this package to be used only on [Travis-CI](https://travis-ci.org) in a scenario where Node is not the primary language.
### Background

To explain, Travis allows you to specify multiple versions for the primary language of a project, leaving any other requirements to be handled by one of these options:
1. other languages, including Node, are included as part of [the default VM image](http://docs.travis-ci.com/user/ci-environment/#Environment-common-to-all-VM-images), the version of which is, (as of today), set to `v0.10.36`
2. pre-build steps can be set which allow you to install any other software you need

We have projects where Node is not the primary language and we need our JS tests to run on Travis in a headless browser. PhantomJS is on all Travis VM images so removing the need for Node to be above `0.12.x` will mean we can use this package.
### Changes made

The checks for PhantomJS I have removed required the use of `execSync` which is only available for versions of Node above `0.10.x`.
### Notes

Once the default version of Node on the Travis VM images is bumped to `0.12.x` or above, the origin project can be used and this repo' will no longer be needed.

Installing Node as a pre-build step will mean this happens every time the build runs and any caching benefits possible from using `apt-get` are unavailable because the versions of Node it provides are currently too old.
### Bugs

A few things have been fixed since this pull request, see these commits for details:
- a0dc36d4c3bc01d66ecbc56def7ea5121aef640c
- 8debcde0e457eff62bc5e736f20b482d896cd396
- 203c1cb2c4e951ff6aac7f3022d0f61111c8d9f4
